### PR TITLE
Improve crouch toggle and jump animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ python game.py
 
 Controls:
 - `A`/`D` or Left/Right arrows to move
-- `Left Shift` to crouch
+- `Left Shift` to toggle crouch
 - `Space`, `W` or Up arrow to jump
 ```


### PR DESCRIPTION
## Summary
- allow toggling crouch using `Left Shift`
- freeze crouch animation on last frame
- animate first frames of jump and hold frame 4 while airborne
- document updated controls

## Testing
- `python -m py_compile game.py`
- `python game.py` *(fails: audio/XDG warnings but runs)*

------
https://chatgpt.com/codex/tasks/task_e_687d9b92696883319c7ffdeb0cdf4e33