### PR TITLE
Implement vertical platform generation and camera follow

### DIFF
--- a/game.py
+++ b/game.py
@@ -10,8 +10,14 @@ class Game:
         pygame.display.set_caption('Hope Sprite Test')
         self.clock = pygame.time.Clock()
         world_width = WIDTH * 3
-        self.level = Level(world_width, HEIGHT, GROUND_HEIGHT)
-        self.player = Player(WIDTH // 2, HEIGHT - GROUND_HEIGHT)
+        world_height = HEIGHT * 3
+        self.player = Player(WIDTH // 2, world_height - GROUND_HEIGHT)
+        self.level = Level(
+            world_width,
+            world_height,
+            GROUND_HEIGHT,
+            player_start=(self.player.x, self.player.y),
+        )
         self.running = True
 
     def run(self):
@@ -22,7 +28,7 @@ class Game:
             self.player.handle_input(keys, dt)
             self.player.apply_physics(self.level, dt)
             self.player.update_animation(dt)
-            self.level.update_camera(self.player.x, WIDTH)
+            self.level.update_camera(self.player.x, self.player.y, WIDTH, HEIGHT)
             self.draw()
         pygame.quit()
 
@@ -38,8 +44,8 @@ class Game:
 
     def draw(self):
         self.screen.fill((255, 255, 255))
-        self.level.draw(self.screen, WIDTH)
-        self.player.draw(self.screen, self.level.camera_x)
+        self.level.draw(self.screen, WIDTH, HEIGHT)
+        self.player.draw(self.screen, self.level.camera_x, self.level.camera_y)
         pygame.display.flip()
 
 if __name__ == '__main__':

--- a/level.py
+++ b/level.py
@@ -5,31 +5,61 @@ class Platform:
         self.rect = rect
         self.mask = pygame.Mask(rect.size, fill=True)
 
-    def draw(self, surface, camera_x=0):
-        pygame.draw.rect(surface, (0, 0, 0), pygame.Rect(self.rect.x - camera_x, self.rect.y, self.rect.width, self.rect.height))
+    def draw(self, surface, camera_x=0, camera_y=0):
+        pygame.draw.rect(
+            surface,
+            (0, 0, 0),
+            pygame.Rect(
+                self.rect.x - camera_x,
+                self.rect.y - camera_y,
+                self.rect.width,
+                self.rect.height,
+            ),
+        )
 
 class Level:
-    def __init__(self, width, height, ground_height):
+    def __init__(self, width, height, ground_height, player_start=None):
         self.width = width
         self.height = height
         self.ground_height = ground_height
         self.platforms = []
-        self.generate()
+        self.generate(player_start)
         self.camera_x = 0
+        self.camera_y = 0
 
-    def generate(self):
+    def generate(self, player_start=None):
+        import random
+
         h = self.height
         gh = self.ground_height
+
+        # Base ground
         self.platforms.append(Platform(pygame.Rect(0, h - gh, self.width, gh)))
-        self.platforms.append(Platform(pygame.Rect(150, h - gh - 120, 200, 20)))
-        self.platforms.append(Platform(pygame.Rect(450, h - gh - 220, 200, 20)))
-        self.platforms.append(Platform(pygame.Rect(50 + 600, h - gh - 180, 220, 20)))
-        self.platforms.append(Platform(pygame.Rect(1100, h - gh - 100, 200, 20)))
-        self.platforms.append(Platform(pygame.Rect(1600, h - gh - 150, 240, 20)))
 
-    def update_camera(self, player_x, screen_width):
+        margin = 60
+        last_y = h - gh - 120
+        for _ in range(10):
+            y = last_y
+            x = random.randint(50, max(50, self.width - 250))
+            rect = pygame.Rect(x, y, 200, 20)
+
+            if player_start:
+                px, py = player_start
+                area = pygame.Rect(px - margin, py - margin, margin * 2, margin * 2)
+                if rect.colliderect(area):
+                    if x < px:
+                        x = max(0, px - rect.width - margin)
+                    else:
+                        x = min(self.width - rect.width, px + margin)
+                    rect.x = x
+
+            self.platforms.append(Platform(rect))
+            last_y -= 150
+
+    def update_camera(self, player_x, player_y, screen_width, screen_height):
         self.camera_x = max(0, min(player_x - screen_width // 2, self.width - screen_width))
+        self.camera_y = max(0, min(player_y - screen_height // 2, self.height - screen_height))
 
-    def draw(self, surface, screen_width):
+    def draw(self, surface, screen_width, screen_height):
         for p in self.platforms:
-            p.draw(surface, self.camera_x)
+            p.draw(surface, self.camera_x, self.camera_y)

--- a/player.py
+++ b/player.py
@@ -116,7 +116,7 @@ class Player:
         self.on_ground = False
         self.resolve_collisions(level.platforms, horizontal=False)
 
-        floor_y = HEIGHT - GROUND_HEIGHT
+        floor_y = level.height - level.ground_height
         if self.y >= floor_y:
             self.y = floor_y
             self.vy = 0
@@ -125,6 +125,7 @@ class Player:
 
         # keep player within level bounds
         self.x = max(self.rect.width // 2, min(level.width - self.rect.width // 2, self.x))
+        self.y = max(self.rect.height // 2, min(self.y, floor_y))
         self.update_rect()
 
     def resolve_collisions(self, platforms, horizontal):
@@ -202,6 +203,6 @@ class Player:
         self.rect.height = height
         self.rect.midbottom = (self.x, self.y)
 
-    def draw(self, surface, camera_x=0):
+    def draw(self, surface, camera_x=0, camera_y=0):
         self.update_rect()
-        surface.blit(self.image, (self.rect.x - camera_x, self.rect.y))
+        surface.blit(self.image, (self.rect.x - camera_x, self.rect.y - camera_y))


### PR DESCRIPTION
## Summary
- add upward platform generation with margin around the player
- track camera position in both axes
- follow the player while drawing
- prevent the player from leaving world bounds vertically

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687da48d8d388331aee07aa14a6956bb